### PR TITLE
Feat/week02-compose-advanced

### DIFF
--- a/app/src/main/java/com/sopt/now/compose/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/now/compose/ui/home/HomeScreen.kt
@@ -1,5 +1,7 @@
 package com.sopt.now.compose.ui.home
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -11,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
@@ -21,13 +24,41 @@ import com.sopt.now.compose.data.Profile
 import com.sopt.now.compose.data.friendList
 import com.sopt.now.compose.data.userProfile
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen() {
+    val (oddFriends, evenFriends) = friendList.partition { it.name.toInt() % 2 != 0 }
+
     LazyColumn {
         item {
             UserProfileItem(userProfile)
         }
-        items(friendList) { friend ->
+
+        stickyHeader {
+            Text(
+                text = "Odd Friends",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.LightGray)
+                    .padding(5.dp),
+                color = Color.Black
+            )
+        }
+        items(items = oddFriends) { friend ->
+            FriendProfileItem(friend)
+        }
+
+        stickyHeader {
+            Text(
+                text = "Even Friends",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.LightGray)
+                    .padding(5.dp),
+                color = Color.Black
+            )
+        }
+        items(items = evenFriends) { friend ->
             FriendProfileItem(friend)
         }
     }


### PR DESCRIPTION
## 작업 내용
- #11 **심화과제**

## 구현화면
https://github.com/NOW-SOPT-ANDROID/seyeong-kong/assets/121383083/e3f8e907-ac32-443d-87b4-9789ccc04f74



## 이슈

**1.** `navController.navigate("login") {
                            popUpTo("mypage") { inclusive = true }
                        } `
이렇게 하면 뒤로 가기 할 때 mypage 페이지를 포함한 모든 스택(?)이 제거 되는 거 아닌가요?
근데 로그아웃 하고 뒤로 가면 아래처럼 나와요.


[week02-compose-advaced-issue1.webm](https://github.com/NOW-SOPT-ANDROID/seyeong-kong/assets/121383083/3d7bfe36-59db-46f8-9731-cdfdb2975f23)


**2.** 마이페이지 탭을 선택한 후 뒤로가기를 하면 포커스는 마이페이지에 있는데, 홈화면이 나와요.

[week02-compose-issue2.webm](https://github.com/NOW-SOPT-ANDROID/seyeong-kong/assets/121383083/7f7b560e-7e91-4de4-b125-4b664748d427)




